### PR TITLE
Flow rate unit is incomplete 131228425

### DIFF
--- a/spec/js/ko-components/view-models/orifice-calculator-spec.coffee
+++ b/spec/js/ko-components/view-models/orifice-calculator-spec.coffee
@@ -146,6 +146,13 @@ define "orifice-calculator-viewmodel-spec", ["knockout", "jasmine-boot", "orific
         viewModel.selectedPipeDiameter config.AvailablePipes.oneNineInch.value
         expect(viewModel.velocityOfApproach()).toEqual 1.02
 
+    describe "availableFlowRateUnits", ->
+      it "should have initialized the input data", ->
+        expect(viewModel.availableFlowRateUnits().length).toEqual 4
+
+      it "should have default value of 'Hour'", ->
+        expect(viewModel.selectedFlowRateUnit()).toEqual config.FlowRateTimeUnits.hour
+
     describe "flowRate", ->
       it "should return the flow rate", ->
         viewModel.orificeBoreDiameter 0.97
@@ -155,7 +162,7 @@ define "orifice-calculator-viewmodel-spec", ["knockout", "jasmine-boot", "orific
         viewModel.differentialPressure 30
         viewModel.baseSpecificGravity 1
         viewModel.operatingTemperature 60
-        viewModel.selectedFlowRateUnit config.AvailableFlowRateUnits.minute
+        viewModel.selectedFlowRateUnit config.FlowRateTimeUnits.minute
         expect(viewModel.flowRate()).toEqual 543.783
 
         viewModel.orificeBoreDiameter 0.776
@@ -165,15 +172,8 @@ define "orifice-calculator-viewmodel-spec", ["knockout", "jasmine-boot", "orific
         viewModel.differentialPressure 30
         viewModel.baseSpecificGravity 1
         viewModel.operatingTemperature 60
-        viewModel.selectedFlowRateUnit config.AvailableFlowRateUnits.minute
+        viewModel.selectedFlowRateUnit config.FlowRateTimeUnits.minute
         expect(viewModel.flowRate()).toEqual 341.328
-
-    describe "availableAvailableFlowRateUnits", ->
-      it "should have initialized the input data", ->
-        expect(viewModel.availableFlowRateUnits().length).toEqual 4
-
-      it "should have default value of 'Minutes'", ->
-        expect(viewModel.selectedFlowRateUnit()).toEqual config.AvailableFlowRateUnits.minute
 
     describe "selectedFlowRateUnit", ->
       beforeEach ->
@@ -186,17 +186,50 @@ define "orifice-calculator-viewmodel-spec", ["knockout", "jasmine-boot", "orific
         viewModel.operatingTemperature 60
 
       it "when minute is chosen", ->
-        viewModel.selectedFlowRateUnit config.AvailableFlowRateUnits.minute
+        viewModel.selectedFlowRateUnit config.FlowRateTimeUnits.minute
         expect(viewModel.flowRate()).toEqual 543.783
 
       it "when hour is chosen", ->
-        viewModel.selectedFlowRateUnit config.AvailableFlowRateUnits.hour
+        viewModel.selectedFlowRateUnit config.FlowRateTimeUnits.hour
         expect(viewModel.flowRate()).toEqual 32626.924
 
       it "when day is chosen", ->
-        viewModel.selectedFlowRateUnit config.AvailableFlowRateUnits.day
+        viewModel.selectedFlowRateUnit config.FlowRateTimeUnits.day
         expect(viewModel.flowRate()).toEqual 783046.156
 
       it "when second is chosen", ->
-        viewModel.selectedFlowRateUnit config.AvailableFlowRateUnits.second
+        viewModel.selectedFlowRateUnit config.FlowRateTimeUnits.second
         expect(viewModel.flowRate()).toEqual 9.064
+
+    describe "availableFlowUnits", ->
+      it "should have the flow units", ->
+        expect(viewModel.availableFlowUnits()).toEqual _.values config.FlowRatePressureUnits
+
+    describe "selectedFlowUnit", ->
+      beforeEach ->
+        viewModel.orificeBoreDiameter 0.97
+        viewModel.selectedPipeDiameter config.AvailablePipes.oneNineInch.value
+        viewModel.operatingPressure 900
+        viewModel.compressibilityCorrectionValue 1
+        viewModel.differentialPressure 30
+        viewModel.baseSpecificGravity 1
+        viewModel.operatingTemperature 60
+
+      it "should have default value of 'standard cubic feet'", ->
+        expect(viewModel.selectedFlowUnit()).toEqual config.FlowRatePressureUnits.standardCubicFeet
+
+      it "when standardCubicFeet is chosen", ->
+        viewModel.selectedFlowUnit config.FlowRatePressureUnits.standardCubicFeet
+        expect(viewModel.flowRate()).toEqual 32712
+
+      it "when pounds is chosen", ->
+        viewModel.selectedFlowUnit config.FlowRatePressureUnits.pounds
+        expect(viewModel.flowRate()).toEqual 2497
+
+      it "when kilograms is chosen", ->
+        viewModel.selectedFlowUnit config.FlowRatePressureUnits.kilograms
+        expect(viewModel.flowRate()).toEqual 1133
+
+      it "when standardCubicMeters is chosen", ->
+        viewModel.selectedFlowUnit config.FlowRatePressureUnits.standardCubicMeters
+        expect(viewModel.flowRate()).toEqual 926.3

--- a/spec/js/ko-components/view-models/orifice-calculator-spec.coffee
+++ b/spec/js/ko-components/view-models/orifice-calculator-spec.coffee
@@ -229,16 +229,16 @@ define "orifice-calculator-viewmodel-spec", ["knockout", "jasmine-boot", "orific
 
       it "when standardCubicFeet is chosen", ->
         viewModel.selectedFlowUnit config.FlowRatePressureUnits.standardCubicFeet
-        expect(viewModel.flowRate()).toEqual 32712
+        expect(viewModel.flowRate()).toEqual 32626.924 #32712
 
       it "when pounds is chosen", ->
         viewModel.selectedFlowUnit config.FlowRatePressureUnits.pounds
-        expect(viewModel.flowRate()).toEqual 2497
+        expect(viewModel.flowRate()).toEqual 2495.96 #2497
 
       it "when kilograms is chosen", ->
         viewModel.selectedFlowUnit config.FlowRatePressureUnits.kilograms
-        expect(viewModel.flowRate()).toEqual 1133
+        expect(viewModel.flowRate()).toEqual 1131.768 #1133
 
       it "when standardCubicMeters is chosen", ->
         viewModel.selectedFlowUnit config.FlowRatePressureUnits.standardCubicMeters
-        expect(viewModel.flowRate()).toEqual 926.3
+        expect(viewModel.flowRate()).toEqual 923.892 #926.3

--- a/spec/js/ko-components/view-models/orifice-calculator-spec.coffee
+++ b/spec/js/ko-components/view-models/orifice-calculator-spec.coffee
@@ -131,6 +131,16 @@ define "orifice-calculator-viewmodel-spec", ["knockout", "jasmine-boot", "orific
           viewModel.selectedCompressibilityCorrection config.CompressibilityCorrection.zf
           expect(viewModel.displayCompressibilityCorrection()).toEqual true
 
+    describe "selectedCompressibilityCorrection", ->
+      beforeEach ->
+        viewModel.selectedCompressibilityCorrection config.CompressibilityCorrection.zf
+        viewModel.compressibilityCorrectionValue 3
+        viewModel.selectedCompressibilityCorrection config.CompressibilityCorrection.none
+
+      describe "when displayCompressibilityCorrection is false", ->
+        it "will displayed the compressibilityCorrectionValue's default value", ->
+          expect(viewModel.compressibilityCorrectionValue()).toEqual 1
+
     describe "betaRatio", ->
       it "should return beta ratio", ->
         viewModel.selectedPipeDiameter config.AvailablePipes.twoZeroInch.value
@@ -210,7 +220,6 @@ define "orifice-calculator-viewmodel-spec", ["knockout", "jasmine-boot", "orific
         viewModel.orificeBoreDiameter 0.97
         viewModel.selectedPipeDiameter config.AvailablePipes.oneNineInch.value
         viewModel.operatingPressure 900
-        viewModel.compressibilityCorrectionValue 1
         viewModel.differentialPressure 30
         viewModel.baseSpecificGravity 1
         viewModel.operatingTemperature 60

--- a/spec/js/ko-components/views/orifice-calculator-spec.coffee
+++ b/spec/js/ko-components/views/orifice-calculator-spec.coffee
@@ -60,5 +60,8 @@ define 'orifice-calculator-view-spec', ['jquery', 'jasmine-jquery'], ($) ->
       it 'should be in the template', ->
         expect($('#flow-rate')).toExist()
 
+    describe 'Flow Unit', ->
+      itShouldBehaveLikeDropdownList '#flow-unit'
+
     describe 'Flow Rate Unit', ->
       itShouldBehaveLikeDropdownList '#flow-rate-unit'

--- a/spec/js/ko-components/views/orifice-calculator-spec.coffee
+++ b/spec/js/ko-components/views/orifice-calculator-spec.coffee
@@ -38,9 +38,6 @@ define "orifice-calculator-view-spec", ["jquery", "jasmine-jquery"], ($) ->
     describe "Basic Specific Gravity", ->
       itShouldBehaveLikeNumberInput '#base-specific-gravity'
 
-    describe "Basic Specific Gravity", ->
-      itShouldBehaveLikeNumberInput "#base-specific-gravity"
-
     describe "Operating Temperature", ->
       itShouldBehaveLikeNumberInput "#operating-temperature"
 

--- a/spec/js/ko-components/views/orifice-calculator-spec.coffee
+++ b/spec/js/ko-components/views/orifice-calculator-spec.coffee
@@ -1,67 +1,70 @@
-define 'orifice-calculator-view-spec', ['jquery', 'jasmine-jquery'], ($) ->
-  describe 'orifice-calculator-view-spec', ->
+define "orifice-calculator-view-spec", ["jquery", "jasmine-jquery"], ($) ->
+  describe "orifice-calculator-view-spec", ->
 
     beforeEach ->
-      jasmine.getFixtures().fixturesPath = 'js/ko-components/templates'
-      loadFixtures 'orifice-calculator.html'
+      jasmine.getFixtures().fixturesPath = "js/ko-components/templates"
+      loadFixtures "orifice-calculator.html"
 
     itShouldBehaveLikeRadioButtons = (element) ->
-      it 'should be radio buttons', ->
+      it "should be radio buttons", ->
         $(element).each ->
-          expect($(this)).toEqual 'INPUT'
-          expect($(this)).toHaveAttr 'type', 'radio'
+          expect($(this)).toEqual "INPUT"
+          expect($(this)).toHaveAttr "type", "radio"
 
     itShouldBehaveLikeDropdownList = (element) ->
-      it 'should be a dropdown list', ->
-        expect($(element)).toEqual 'SELECT'
+      it "should be a dropdown list", ->
+        expect($(element)).toEqual "SELECT"
 
     itShouldBehaveLikeNumberInput = (element) ->
-      it 'should be number input', ->
-        expect($(element)).toEqual 'INPUT'
-        expect($(element)).toHaveAttr 'type', 'number'
+      it "should be number input", ->
+        expect($(element)).toEqual "INPUT"
+        expect($(element)).toHaveAttr "type", "number"
 
-    describe 'Available Pipes', ->
-      itShouldBehaveLikeDropdownList '#available-pipes'
+    describe "Available Pipes", ->
+      itShouldBehaveLikeDropdownList "#available-pipes"
 
-    describe 'Operating Pressure', ->
-      itShouldBehaveLikeNumberInput '#operating-pressure'
+    describe "Operating Pressure", ->
+      itShouldBehaveLikeNumberInput "#operating-pressure"
 
-    describe 'Operating Pressure Read', ->
-      itShouldBehaveLikeRadioButtons '.operating-pressure-read'
+    describe "Operating Pressure Read", ->
+      itShouldBehaveLikeRadioButtons ".operating-pressure-read"
 
-    describe 'Operating Pressure Units', ->
-      itShouldBehaveLikeDropdownList '#operating-pressure-units'
+    describe "Operating Pressure Units", ->
+      itShouldBehaveLikeDropdownList "#operating-pressure-units"
 
-    describe 'Available Basic Specific Gravity', ->
+    describe "Available Basic Specific Gravity", ->
       itShouldBehaveLikeDropdownList '#base-specific-gravity-select'
 
-    describe 'Basic Specific Gravity', ->
+    describe "Basic Specific Gravity", ->
       itShouldBehaveLikeNumberInput '#base-specific-gravity'
 
-    describe 'Operating Temperature', ->
-      itShouldBehaveLikeNumberInput '#operating-temperature'
+    describe "Basic Specific Gravity", ->
+      itShouldBehaveLikeNumberInput "#base-specific-gravity"
 
-    describe 'Operating Temperature Units', ->
-      itShouldBehaveLikeRadioButtons '.operating-temperature-units'
+    describe "Operating Temperature", ->
+      itShouldBehaveLikeNumberInput "#operating-temperature"
 
-    describe 'Differential Pressure', ->
-      itShouldBehaveLikeNumberInput '#differential-pressure'
+    describe "Operating Temperature Units", ->
+      itShouldBehaveLikeRadioButtons ".operating-temperature-units"
 
-    describe 'Orifice Bore Diameter', ->
-      itShouldBehaveLikeNumberInput '#orifice-bore-diameter'
+    describe "Differential Pressure", ->
+      itShouldBehaveLikeNumberInput "#differential-pressure"
 
-    describe 'Compressibility Correction', ->
-      itShouldBehaveLikeRadioButtons '.compressibility-correction'
+    describe "Orifice Bore Diameter", ->
+      itShouldBehaveLikeNumberInput "#orifice-bore-diameter"
 
-    describe 'Compressibility Correction Value', ->
-      itShouldBehaveLikeNumberInput '#compressibility-correction-value'
+    describe "Compressibility Correction", ->
+      itShouldBehaveLikeRadioButtons ".compressibility-correction"
 
-    describe 'Flow Rate', ->
-      it 'should be in the template', ->
-        expect($('#flow-rate')).toExist()
+    describe "Compressibility Correction Value", ->
+      itShouldBehaveLikeNumberInput "#compressibility-correction-value"
 
-    describe 'Flow Unit', ->
+    describe "Flow Rate", ->
+      it "should be in the template", ->
+        expect($("#flow-rate")).toExist()
+
+    describe "Flow Unit", ->
       itShouldBehaveLikeDropdownList '#flow-unit'
 
-    describe 'Flow Rate Unit', ->
-      itShouldBehaveLikeDropdownList '#flow-rate-unit'
+    describe "Flow Rate Unit", ->
+      itShouldBehaveLikeDropdownList "#flow-rate-unit"

--- a/src/js/ko-components/config/dictionaries.coffee
+++ b/src/js/ko-components/config/dictionaries.coffee
@@ -108,7 +108,13 @@ define "orifice-calculator-config", () ->
     differentialPressureError: "Please enter the differential pressure"
     orificeBoreDiameterError: "Please enter the orifice bore diameter"
 
-  @OPL.OrificeCalculator.Config.Dictionaries.AvailableFlowRateUnits =
+  @OPL.OrificeCalculator.Config.Dictionaries.FlowRatePressureUnits =
+    standardCubicFeet: "Standard Cubic Feet"
+    pounds: "Pounds"
+    kilograms: "Kilograms"
+    standardCubicMeters: "Standard Cubic Meters"
+
+  @OPL.OrificeCalculator.Config.Dictionaries.FlowRateTimeUnits =
     minute: "Minute"
     hour: "Hour"
     day: "Day"

--- a/src/js/ko-components/templates/orifice-calculator.haml
+++ b/src/js/ko-components/templates/orifice-calculator.haml
@@ -105,5 +105,9 @@
       .help-block#copy-feedback.animated(data-bind="css: copyFeedbackClass") Copied
 
     .col-xs-12.col-sm-4
+      %label(for="flow-rate-unit") Flow Unit
+      %select.form-control#flow-unit(data-bind="options: availableFlowUnits, value: selectedFlowUnit")
+
+    .col-xs-12.col-sm-3
       %label(for="flow-rate-unit") Rate Unit
       %select.form-control#flow-rate-unit(data-bind="options: availableFlowRateUnits, value: selectedFlowRateUnit")

--- a/src/js/ko-components/view-models/orifice-calculator.coffee
+++ b/src/js/ko-components/view-models/orifice-calculator.coffee
@@ -106,12 +106,9 @@ define "orifice-calculator-viewmodel", ["knockout", "lodash", "knockout.validati
       @displayCompressibilityCorrection = ko.computed =>
         @selectedCompressibilityCorrection() != config.CompressibilityCorrection.none
 
-      @compressibilityCorrectionValue = ko.observable()
-      @displayCompressibilityCorrection.subscribe (newValue) =>
-        if newValue
-          @compressibilityCorrectionValue 1
-        else
-          @compressibilityCorrectionValue undefined
+      @compressibilityCorrectionValue = ko.observable(1)
+      @displayCompressibilityCorrection.subscribe (isDisplayed) =>
+        @compressibilityCorrectionValue 1 unless isDisplayed
 
       @betaRatio = ko.computed =>
         betaRatio = _.ceil @orificeBoreDiameterInInches() / @selectedPipeDiameter(), 5

--- a/src/js/ko-components/view-models/orifice-calculator.coffee
+++ b/src/js/ko-components/view-models/orifice-calculator.coffee
@@ -143,7 +143,7 @@ define "orifice-calculator-viewmodel", ["knockout", "lodash", "knockout.validati
 
         # NOTE: The flowRate will be always converted from standardCubicFeet since this is the final units of the calculation
         if @selectedFlowUnit() != config.FlowRatePressureUnits.standardCubicFeet
-          flowRate = OPL.Converter.Flowrate.convert(config.FlowRatePressureUnits.standardCubicFeet, @selectedFlowUnit(), flowRate)
+          flowRate = OPL.Converter.FlowRate.convert(config.FlowRatePressureUnits.standardCubicFeet, @selectedFlowUnit(), flowRate)
 
         if _.isNaN flowRate
           return undefined

--- a/src/js/ko-components/view-models/orifice-calculator.coffee
+++ b/src/js/ko-components/view-models/orifice-calculator.coffee
@@ -144,7 +144,9 @@ define "orifice-calculator-viewmodel", ["knockout", "lodash", "knockout.validati
           when config.FlowRateTimeUnits.minute then flowRate /= 60
           when config.FlowRateTimeUnits.second then flowRate /= 3600
 
-        OPL.Converter.Flowrate.convert(config.FlowRatePressureUnits.standardCubicFeet, @selectedFlowUnit(), flowRate)
+        # NOTE: The flowRate will be always converted from standardCubicFeet since this is the final units of the calculation
+        if @selectedFlowUnit() != config.FlowRatePressureUnits.standardCubicFeet
+          flowRate = OPL.Converter.Flowrate.convert(config.FlowRatePressureUnits.standardCubicFeet, @selectedFlowUnit(), flowRate)
 
         if _.isNaN flowRate
           return undefined

--- a/src/js/ko-components/view-models/orifice-calculator.coffee
+++ b/src/js/ko-components/view-models/orifice-calculator.coffee
@@ -121,7 +121,7 @@ define "orifice-calculator-viewmodel", ["knockout", "lodash", "knockout.validati
       @velocityOfApproach = ko.computed =>
         _.ceil (1 / Math.sqrt(1 - @betaRatio() ** 4)), 2
 
-      @availableFlowRateUnits = ko.observableArray _.values config.AvailableFlowRateUnits
+      @availableFlowRateUnits = ko.observableArray _.values config.FlowRateTimeUnits
       @selectedFlowRateUnit = ko.observable config.AvailableFlowRateUnits.minute
 
       @operatingTemperatureInRankine = ko.pureComputed =>

--- a/src/js/ko-components/view-models/orifice-calculator.coffee
+++ b/src/js/ko-components/view-models/orifice-calculator.coffee
@@ -121,8 +121,11 @@ define "orifice-calculator-viewmodel", ["knockout", "lodash", "knockout.validati
       @velocityOfApproach = ko.computed =>
         _.ceil (1 / Math.sqrt(1 - @betaRatio() ** 4)), 2
 
+      @availableFlowUnits = ko.observableArray _.values config.FlowRatePressureUnits
+      @selectedFlowUnit = ko.observable config.FlowRatePressureUnits.standardCubicFeet
+
       @availableFlowRateUnits = ko.observableArray _.values config.FlowRateTimeUnits
-      @selectedFlowRateUnit = ko.observable config.AvailableFlowRateUnits.minute
+      @selectedFlowRateUnit = ko.observable config.FlowRateTimeUnits.minute
 
       @operatingTemperatureInRankine = ko.pureComputed =>
         switch @selectedOperatingTemperatureUnit()
@@ -137,9 +140,9 @@ define "orifice-calculator-viewmodel", ["knockout", "lodash", "knockout.validati
 
         # TODO: Find a better way of doing this. Maybe something related to ko.subscription?
         switch @selectedFlowRateUnit()
-          when config.AvailableFlowRateUnits.day then flowRate *= 24
-          when config.AvailableFlowRateUnits.minute then flowRate /= 60
-          when config.AvailableFlowRateUnits.second then flowRate /= 3600
+          when config.FlowRateTimeUnits.day then flowRate *= 24
+          when config.FlowRateTimeUnits.minute then flowRate /= 60
+          when config.FlowRateTimeUnits.second then flowRate /= 3600
 
         if _.isNaN flowRate
           return undefined

--- a/src/js/ko-components/view-models/orifice-calculator.coffee
+++ b/src/js/ko-components/view-models/orifice-calculator.coffee
@@ -125,7 +125,7 @@ define "orifice-calculator-viewmodel", ["knockout", "lodash", "knockout.validati
       @selectedFlowUnit = ko.observable config.FlowRatePressureUnits.standardCubicFeet
 
       @availableFlowRateUnits = ko.observableArray _.values config.FlowRateTimeUnits
-      @selectedFlowRateUnit = ko.observable config.FlowRateTimeUnits.minute
+      @selectedFlowRateUnit = ko.observable config.FlowRateTimeUnits.hour
 
       @operatingTemperatureInRankine = ko.pureComputed =>
         switch @selectedOperatingTemperatureUnit()
@@ -143,6 +143,8 @@ define "orifice-calculator-viewmodel", ["knockout", "lodash", "knockout.validati
           when config.FlowRateTimeUnits.day then flowRate *= 24
           when config.FlowRateTimeUnits.minute then flowRate /= 60
           when config.FlowRateTimeUnits.second then flowRate /= 3600
+
+        OPL.Converter.Flowrate.convert(config.FlowRatePressureUnits.standardCubicFeet, @selectedFlowUnit(), flowRate)
 
         if _.isNaN flowRate
           return undefined

--- a/src/js/lib/converter.js.coffee
+++ b/src/js/lib/converter.js.coffee
@@ -4,6 +4,7 @@ define "unit-converter", ["lodash"], (_) ->
   @OPL.Converter.Dimensions ||= {}
   @OPL.Converter.Temperature ||= {}
   @OPL.Converter.Pressure ||= {}
+  @OPL.Converter.Flowrate ||= {}
 
   _.extend @OPL.Converter.Dimensions,
     ONE_CM_IN_INCHES: 0.3937007874
@@ -55,6 +56,31 @@ define "unit-converter", ["lodash"], (_) ->
         "inh2o": 0.039370087
       "psi":
         "inh2o": 27.7075924
+
+    convert: (from, to, value) ->
+      @CONSTANTS[from][to] * value
+
+  _.extend @OPL.Converter.Flowrate,
+    # STANDARD_AIR_DENSITY: 1.225
+    # AMERICAN_AIR_DENSITY: 0.0765
+
+    CONSTANTS:
+      "Standard Cubic Feet":
+        "Pounds": 0.0765
+        "Kilograms": 0.3048 ** 3 * 1.225
+        "Standard Cubic Meters": 0.3048 ** 3
+      # "Pounds":
+      #   "Standard Cubic Feet": 1 / 0.0765
+      #   "Kilograms": 0.454
+      #   "Standard Cubic Meters": 0.454 / 1.225
+      # "Kilograms":
+      #   "Pounds": 1 / 0.454
+      #   "Standard Cubic Feet": (1 / 0.454) / 0.0765
+      #   "Standard Cubic Meters": 1.225
+      # "Standard Cubic Meters":
+      #   "Pounds": ( 1.225 / 0.454 )
+      #   "Kilograms": 1 / 1.225
+      #   "Standard Cubic Feet": 3.281 ** 3
 
     convert: (from, to, value) ->
       @CONSTANTS[from][to] * value

--- a/src/js/lib/converter.js.coffee
+++ b/src/js/lib/converter.js.coffee
@@ -4,7 +4,7 @@ define "unit-converter", ["lodash"], (_) ->
   @OPL.Converter.Dimensions ||= {}
   @OPL.Converter.Temperature ||= {}
   @OPL.Converter.Pressure ||= {}
-  @OPL.Converter.Flowrate ||= {}
+  @OPL.Converter.FlowRate ||= {}
 
   _.extend @OPL.Converter.Dimensions,
     ONE_CM_IN_INCHES: 0.3937007874
@@ -60,7 +60,7 @@ define "unit-converter", ["lodash"], (_) ->
     convert: (from, to, value) ->
       @CONSTANTS[from][to] * value
 
-  _.extend @OPL.Converter.Flowrate,
+  _.extend @OPL.Converter.FlowRate,
     CONSTANTS:
       "Standard Cubic Feet":
         "Pounds": 0.0765

--- a/src/js/lib/converter.js.coffee
+++ b/src/js/lib/converter.js.coffee
@@ -61,26 +61,11 @@ define "unit-converter", ["lodash"], (_) ->
       @CONSTANTS[from][to] * value
 
   _.extend @OPL.Converter.Flowrate,
-    # STANDARD_AIR_DENSITY: 1.225
-    # AMERICAN_AIR_DENSITY: 0.0765
-
     CONSTANTS:
       "Standard Cubic Feet":
         "Pounds": 0.0765
         "Kilograms": 0.3048 ** 3 * 1.225
         "Standard Cubic Meters": 0.3048 ** 3
-      # "Pounds":
-      #   "Standard Cubic Feet": 1 / 0.0765
-      #   "Kilograms": 0.454
-      #   "Standard Cubic Meters": 0.454 / 1.225
-      # "Kilograms":
-      #   "Pounds": 1 / 0.454
-      #   "Standard Cubic Feet": (1 / 0.454) / 0.0765
-      #   "Standard Cubic Meters": 1.225
-      # "Standard Cubic Meters":
-      #   "Pounds": ( 1.225 / 0.454 )
-      #   "Kilograms": 1 / 1.225
-      #   "Standard Cubic Feet": 3.281 ** 3
 
     convert: (from, to, value) ->
       @CONSTANTS[from][to] * value


### PR DESCRIPTION
@opsmanager/developers , have a look on this? 😄 

To convert the mass flow rate (pound/time, kg/time) to volumetric flow rate (feet3/time, m3/time), I used this formula. 

mass flow rate x density of air = volumetric flow rate

I assumed the density of air to be 1.225kg/m3 for all scenario (actually this is only true in 15 celsius and 101.325kPa, see [here](http://engineering.stackexchange.com/questions/2561/converting-air-flow-rate-between-kg-s-and-m3-s) ),since the software seems like using this for different temperature and pressure as well.  